### PR TITLE
Fix typo in songs.json entry

### DIFF
--- a/songs.json
+++ b/songs.json
@@ -32,7 +32,7 @@
     {
         "title": "hurry, or we'll miss the train",
         "audioFile": "hurry-or-well-miss-the-train.mp3",
-        "description": "it's time to go. percussion drives urgency, brass bellow defiantly. the musicians grab their instruments, and move decisively, leaving hesitation behind. as the train steams ahead, sounds collide deliberately, confident and unapologetic, racing forward to unknown places."
+        "description": "it's time to go. percussion drives urgency, brass bellows defiantly. the musicians grab their instruments, and move decisively, leaving hesitation behind. as the train steams ahead, sounds collide deliberately, confident and unapologetic, racing forward to unknown places."
     },
     {
         "title": "dancing with ghosts",


### PR DESCRIPTION
## Summary
- correct 'brass bellow' to 'brass bellows' in the song description for "hurry, or we'll miss the train"

## Testing
- `jq . songs.json`