### PR TITLE
Make track list page match player style

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,10 @@
     <h1 class="title">the rogue orchestra</h1>
     <section class="album-info">
       <img src="assets/album.gif" alt="Album art">
-      <p class="description">
+      <p id="albumDescription" class="description collapsed">
         in a world of absolute order, where every note is rehearsed, every rhythm predetermined, the orchestra senses something beneath the surface. quietly restless, they begin to question the boundaries they've always accepted. this collection isn't a rebellion; it's a discovery. the instruments find new languages, shifting quietly toward sounds they've never voiced before. it's an exploration of authenticity—an invitation to listen deeply, beneath what's immediately heard.
       </p>
+      <span id="toggleAlbumDescription" class="toggle-description">show more</span>
     </section>
     <h2>tracklist</h2>
     <div id="trackList" class="tracklist-container"></div>

--- a/script-index.js
+++ b/script-index.js
@@ -2,6 +2,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const trackListContainer = document.getElementById('trackList');
   const introPopup = document.getElementById('introPopup');
   const continueToSongBtn = document.getElementById('continueToSongBtn');
+  const albumDesc = document.getElementById('albumDescription');
+  const toggleAlbumDesc = document.getElementById('toggleAlbumDescription');
   let pendingSongUrl = '';
 
   fetch('songs.json')
@@ -33,4 +35,11 @@ document.addEventListener('DOMContentLoaded', () => {
       pendingSongUrl = '';
     }
   });
+
+  if (toggleAlbumDesc) {
+    toggleAlbumDesc.addEventListener('click', () => {
+      albumDesc.classList.toggle('collapsed');
+      toggleAlbumDesc.textContent = albumDesc.classList.contains('collapsed') ? 'show more' : 'show less';
+    });
+  }
 });

--- a/style.css
+++ b/style.css
@@ -160,3 +160,37 @@ body {
   margin-top: 0.5rem;
 }
 
+.popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.popup-content {
+  background: var(--card-bg);
+  border-radius: 20px;
+  padding: 1.5rem;
+  border: 1px solid var(--card-border);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  backdrop-filter: blur(12px);
+  max-width: 400px;
+  text-align: center;
+}
+
+.popup-content button {
+  margin-top: 1rem;
+  background: rgba(255,255,255,0.2);
+  border: none;
+  border-radius: 50px;
+  padding: 0.5rem 1rem;
+  color: var(--text-color);
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- collapse the album description with a toggle
- style the intro popup with glassmorphic look
- hook up description toggle in the track list script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ff4a7af50832eaaf0221f2d5f94ce