### PR TITLE
Fix track width and first-time popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <button id="themeSwitcherBtn" class="theme-btn"><i class="fas fa-moon"></i></button>
-  <div class="container">
+  <div class="container full-width">
     <h1 class="title">the rogue orchestra</h1>
     <section class="album-info">
       <img src="assets/album.gif" alt="Album art">

--- a/script-index.js
+++ b/script-index.js
@@ -16,8 +16,13 @@ document.addEventListener('DOMContentLoaded', () => {
         link.className = 'track-link';
         link.addEventListener('click', (e) => {
           e.preventDefault();
-          pendingSongUrl = link.href;
-          introPopup.style.display = 'flex';
+          if (!localStorage.getItem('introShown')) {
+            pendingSongUrl = link.href;
+            introPopup.style.display = 'flex';
+            localStorage.setItem('introShown', 'true');
+          } else {
+            window.location.href = link.href;
+          }
         });
         trackListContainer.appendChild(link);
       });

--- a/script-song.js
+++ b/script-song.js
@@ -33,6 +33,17 @@ document.addEventListener('DOMContentLoaded', () => {
     progressBar.value = 0;
     currentTimeEl.textContent = '0:00';
     durationEl.textContent = '0:00';
+
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: song.title,
+        artist: 'the rogue orchestra',
+        album: 'the rogue orchestra',
+        artwork: [
+          { src: 'assets/album.gif', sizes: '512x512', type: 'image/gif' }
+        ]
+      });
+    }
   }
 
   function formatTime(t) {
@@ -59,6 +70,15 @@ document.addEventListener('DOMContentLoaded', () => {
     audio.play();
     playPauseBtn.innerHTML = '<i class="fas fa-pause"></i>';
   });
+
+  if ('mediaSession' in navigator) {
+    navigator.mediaSession.setActionHandler('previoustrack', () => {
+      prevBtn.click();
+    });
+    navigator.mediaSession.setActionHandler('nexttrack', () => {
+      nextBtn.click();
+    });
+  }
 
   nextBtn.addEventListener('click', () => {
     if (songsData.length === 0) return;

--- a/style.css
+++ b/style.css
@@ -38,6 +38,10 @@ body {
   backdrop-filter: blur(12px);
 }
 
+.container.full-width {
+  max-width: none;
+}
+
 .title {
   text-align: center;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- let index page container stretch full width
- only show intro popup on first track click using localStorage
- allow media controls to change tracks via Media Session API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ff6c7424c832e95239b7b4fabda4f