### PR TITLE
Improve track visuals and playback

### DIFF
--- a/script-index.js
+++ b/script-index.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const link = document.createElement('a');
         link.href = `song.html?song=${index}`;
         link.textContent = song.title;
-        link.className = 'track-link';
+        link.className = 'track-button';
         link.addEventListener('click', (e) => {
           e.preventDefault();
           if (!localStorage.getItem('introShown')) {

--- a/script-song.js
+++ b/script-song.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const titleEl = document.getElementById('songTitle');
   const descEl = document.getElementById('songDescription');
   const audio = document.getElementById('audioPlayer');
+  const introEl = document.getElementById("songIntro");
+  const container = document.querySelector(".container");
   const toggle = document.getElementById('toggleDescription');
   const backLink = document.getElementById('backLink');
 
@@ -28,12 +30,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const song = songsData[i];
     if (!song) return;
     titleEl.textContent = song.title;
-    descEl.innerHTML = song.description;
+    const match = song.description.match(/^<em>(.*?)<\/em><br>?/);
+    if (match) {
+      introEl.innerHTML = match[1];
+      introEl.style.display = "block";
+      descEl.innerHTML = song.description.replace(match[0], "");
+    } else {
+      introEl.style.display = "none";
+      descEl.innerHTML = song.description;
+    }
     audio.src = `assets/${song.audioFile}`;
     progressBar.value = 0;
     currentTimeEl.textContent = '0:00';
     durationEl.textContent = '0:00';
-
+    container.classList.remove('fade-in');
+    void container.offsetWidth;
+    container.classList.add('fade-in');
     if ('mediaSession' in navigator) {
       navigator.mediaSession.metadata = new MediaMetadata({
         title: song.title,
@@ -45,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
   }
+
 
   function formatTime(t) {
     if (!t || isNaN(t)) return '0:00';

--- a/song.html
+++ b/song.html
@@ -9,11 +9,12 @@
 </head>
 <body>
   <button id="themeSwitcherBtn" class="theme-btn"><i class="fas fa-moon"></i></button>
-  <div class="container">
+  <div class="container fade-in">
     <a href="#" id="backLink" class="back-link">← back to album</a>
     <h1 class="title">the rogue orchestra</h1>
     <img src="assets/album.gif" alt="Album art" id="albumArt">
     <h2 id="songTitle" class="song-title"></h2>
+    <p id="songIntro" class="intro"></p>
     <h3 class="artist">the rogue orchestra</h3>
     <div class="progress-container">
       <span id="currentTime">0:00</span>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 :root {
   --bg-start: #000;
-  --bg-end: #0f766e;
+  --bg-end: #065f46;
   --card-bg: rgba(0,0,0,0.4);
   --card-border: rgba(255,255,255,0.2);
   --text-color: #eee;
@@ -8,7 +8,7 @@
 }
 body.light-mode {
   --bg-start: #fff;
-  --bg-end: #0f766e;
+  --bg-end: #0891b2;
   --card-bg: rgba(255,255,255,0.6);
   --card-border: rgba(0,0,0,0.1);
   --text-color: #111;
@@ -62,14 +62,21 @@ body {
   margin-top: 1rem;
 }
 
-.track-link {
+.track-button {
   display: block;
-  margin: 0.25rem 0;
-  color: var(--accent);
+  padding: 0.75rem 1rem;
+  margin: 0.5rem 0;
+  color: var(--text-color);
   text-decoration: none;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  text-align: center;
 }
-.track-link:hover {
-  text-decoration: underline;
+.track-button:hover {
+  background: rgba(255,255,255,0.1);
 }
 
 .controls {
@@ -198,3 +205,16 @@ body {
   cursor: pointer;
 }
 
+.intro {
+  font-style: italic;
+  margin-top: 0.5rem;
+}
+
+.fade-in {
+  animation: fadeMove 0.4s ease;
+}
+
+@keyframes fadeMove {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- deepen gradient colours
- style track list links as buttons
- add intro snippet display on song page
- animate track transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ffc808d7c832e8b20fdeacc80a373